### PR TITLE
Add support for io

### DIFF
--- a/dibuparser/parser.py
+++ b/dibuparser/parser.py
@@ -93,7 +93,7 @@ class ImmediateFriendlyVisitor(Visitor):
         IMMEDIATE_LENGTH = 8
         match value.data:
             case "binary": return Bits(bin=value.children[0].value, length=IMMEDIATE_LENGTH).bin
-            case "hexa": return Bits(hex=value.children[0].value, length=IMMEDIATE_LENGTH).bin
+            case "hexa": return Bits(uint=int(value.children[0].value, base=16), length=IMMEDIATE_LENGTH).bin
             case "decimal": return Bits(int=int(value.children[0].value[2:]), length=IMMEDIATE_LENGTH).bin
             case _: raise ValueError("unsupported immediate operand type: %s" % (value.data))
 

--- a/rtl/constants.v
+++ b/rtl/constants.v
@@ -26,3 +26,7 @@
 `define JE 3'b001
 `define JNE 3'b010
 `define JN 3'b011
+
+// io
+`define IO_IN_ADDR 10'hfe
+`define IO_OUT_ADDR 10'hff

--- a/rtl/datapath.v
+++ b/rtl/datapath.v
@@ -168,8 +168,8 @@ module datapath(clk, run, code_w_en, code_addr_in, code_in, io_in, io_out);
     //
 
     wire is_io_addr, is_io_out;
-    assign is_io_out = (dar_out == 10'h3ff);
-    assign is_io_addr = (dar_out == 10'h3fe) | is_io_out;
+    assign is_io_out = (dar_out === `IO_OUT_ADDR);
+    assign is_io_addr = (dar_out === `IO_IN_ADDR) | is_io_out;
     
 
     register #(4) io_out_register(

--- a/rtl/pc_module.v
+++ b/rtl/pc_module.v
@@ -20,7 +20,7 @@ module pc_module(clk, pc_inc, pc_ref_inc, pc_ref_dec, pc_set, pc_set_value, pc_o
 
     initial
     begin    
-        for (i=0; i<8; i++) begin
+        for (i=0; i<8; i=i+1) begin
             pc_bank[i] = 9'd0;
         end
         

--- a/rtl_tests/test_datapath.py
+++ b/rtl_tests/test_datapath.py
@@ -198,10 +198,11 @@ async def test_store_load_direct(dut):
 
 @cocotb.test()
 async def test_write_from_reg_to_ioout(dut):
-    test_program = """IO_OUT_ADDR = 0x3ff
-    IO_IN_ADDR = 0x3fe
-    mov r3 0x13
+    test_program = """IO_OUT_ADDR = 0xff
+    IO_IN_ADDR = 0xfe
+    mov r3 0b00001100
     str [$IO_OUT_ADDR] r3
+    load r4 [$IO_IN_ADDR]
     halt 
     """
     test_compiled_program = assemble(parse(test_program))
@@ -226,13 +227,15 @@ async def test_write_from_reg_to_ioout(dut):
 
     dut.code_w_en.value = 0
     dut.run.value = 1
+    dut.io_in.value = BinaryValue(value="0011", n_bits=4)
 
     dut._log.info("arranco a ejecutar")
 
     # memory has been written
     await wait_until_halt(dut)
 
-    assert dut.io_out == int("0x13", base=16)
+    assert dut.io_out == int("0b1100", base=2)
+    assert dut.rbank.bank.value[4] == int("0x03", base=16)
 
 @cocotb.test()
 async def test_store_load_indirect(dut):

--- a/rtl_tests/test_datapath.py
+++ b/rtl_tests/test_datapath.py
@@ -197,6 +197,44 @@ async def test_store_load_direct(dut):
     assert dut.rbank.bank.value[4] == int("0x13", base=16)
 
 @cocotb.test()
+async def test_write_from_reg_to_ioout(dut):
+    test_program = """IO_OUT_ADDR = 0x3ff
+    IO_IN_ADDR = 0x3fe
+    mov r3 0x13
+    str [$IO_OUT_ADDR] r3
+    halt 
+    """
+    test_compiled_program = assemble(parse(test_program))
+    print("programa compilado: \n%s" % (test_compiled_program))
+
+    dut.run.value = 0
+    dut.code_w_en.value = 0
+    cocotb.start_soon(Clock(dut.clk, 10, units="ns").start())
+
+    # wait a bit, 2 clk cycles
+    await Timer(20, units="ns")
+    await FallingEdge(dut.clk)
+
+    # write program
+    dut.code_w_en.value = 1
+    for i, l in enumerate(test_compiled_program.splitlines(keepends=False)):
+        dut.code_addr_in.value = i
+        dut.code_in.value = BinaryValue(l)
+        await FallingEdge(dut.clk)
+
+    # im in a falling edge, and code has been written
+
+    dut.code_w_en.value = 0
+    dut.run.value = 1
+
+    dut._log.info("arranco a ejecutar")
+
+    # memory has been written
+    await wait_until_halt(dut)
+
+    assert dut.io_out == int("0x13", base=16)
+
+@cocotb.test()
 async def test_store_load_indirect(dut):
     test_program = """mov r0 0x15
     mov r3 0x13

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -101,20 +101,20 @@ class ParserTest(unittest.TestCase):
                     (OperandType.IMMEDIATE, "0"*8),
                 ]),
                 Instruction("jmp", [
-                    (OperandType.LABELOrVAR, "start"),
+                    (OperandType.LABEL, "start"),
                 ]),
                 Instruction("halt", []),
                 Instruction("jmp", [
-                    (OperandType.LABELOrVAR, "end"),
+                    (OperandType.LABEL, "end"),
                 ]),
                 Instruction("je", [
-                    (OperandType.LABELOrVAR, "end"),
+                    (OperandType.LABEL, "end"),
                 ]),
                 Instruction("jne", [
-                    (OperandType.LABELOrVAR, "end"),
+                    (OperandType.LABEL, "end"),
                 ]),
                 Instruction("jn", [
-                    (OperandType.LABELOrVAR, "end"),
+                    (OperandType.LABEL, "end"),
                 ]),
             ],
             labels={
@@ -135,7 +135,6 @@ class ParserTest(unittest.TestCase):
         """)
         assembled_program = assemble(prog)
         self.assertEqual(expected, assembled_program)
-
 
     def test_parse_error(self):
         example = """mov r1 0jd0129
@@ -168,7 +167,6 @@ class ParserTest(unittest.TestCase):
         # log the exception
         print(ctx.exception)
 
-
     def test_parser_with_variables_use(self):
         example = """MODE = 0xf0
         str [$MODE] 0x0f
@@ -178,8 +176,29 @@ class ParserTest(unittest.TestCase):
         prog = parse(example)
         expected = Program(
             instructions=[
-                Instruction("str", [(OperandType.MEM_IMMEDIATE, "11110000"), (OperandType.IMMEDIATE, "00001111")]),
-                Instruction("mov", [(OperandType.REGISTER, "r1"), (OperandType.IMMEDIATE, "11110000")]),
+                Instruction("str", [
+                            (OperandType.MEM_IMMEDIATE, "11110000"), (OperandType.IMMEDIATE, "00001111")]),
+                Instruction("mov", [(OperandType.REGISTER, "r1"),
+                            (OperandType.IMMEDIATE, "11110000")]),
+                Instruction("halt", [])
+            ],
+            labels={},
+        )
+        self.assertEqual(prog, expected)
+
+    def test_immediate_are_padded_to_correct_length(self):
+        example = """MODE = 0x3
+        str [$MODE] 0x0f
+        mov r1 $MODE
+        halt
+        """
+        prog = parse(example)
+        expected = Program(
+            instructions=[
+                Instruction("str", [
+                            (OperandType.MEM_IMMEDIATE, "00000011"), (OperandType.IMMEDIATE, "00001111")]),
+                Instruction("mov", [(OperandType.REGISTER, "r1"),
+                            (OperandType.IMMEDIATE, "00000011")]),
                 Instruction("halt", [])
             ],
             labels={},

--- a/vivado/dibu-softcore.xpr
+++ b/vivado/dibu-softcore.xpr
@@ -126,6 +126,13 @@
           <Attr Name="UsedIn" Val="simulation"/>
         </FileInfo>
       </File>
+      <File Path="$PPRDIR/../rtl/pc_module.v">
+        <FileInfo>
+          <Attr Name="UsedIn" Val="synthesis"/>
+          <Attr Name="UsedIn" Val="implementation"/>
+          <Attr Name="UsedIn" Val="simulation"/>
+        </FileInfo>
+      </File>
       <File Path="$PPRDIR/../rtl/register.v">
         <FileInfo>
           <Attr Name="UsedIn" Val="synthesis"/>


### PR DESCRIPTION
- Added support for IO instructions. Right now the IO ports are `0xfe` and `0xff`, the last direction able addressed
- Add tests for IO
- Fix parser bug