### PR TITLE
Macros, some fixes and initial simon work

### DIFF
--- a/dibuparser/__init__.py
+++ b/dibuparser/__init__.py
@@ -1,1 +1,1 @@
-from .parser import parse, Program, Instruction, OperandType, assemble
+from .parser import parse, Program, Instruction, OperandType, assemble, apply_macros

--- a/dibuparser/grammar.lark
+++ b/dibuparser/grammar.lark
@@ -51,7 +51,7 @@ immediate: IMM_BINARY -> binary
 
 IMM_BINARY: "0b" ("0" | "1")+
 IMM_HEXA: "0x" (DIGIT | "a".."f")+
-IMM_DECI: "0d" DIGIT+
+IMM_DECI: "0d" "-"? DIGIT+
 IMM_UINT: "0u" DIGIT+
 
 EOL: "\n"

--- a/dibuparser/grammar.lark
+++ b/dibuparser/grammar.lark
@@ -14,7 +14,7 @@ opcode: OPCODE
 
 OPCODE: "mov"
     | "movf"
-    | "add"
+    | "add" | "addi"
     | "sub"
     | "and"
     | "or"

--- a/dibuparser/parser.py
+++ b/dibuparser/parser.py
@@ -178,14 +178,14 @@ def apply_macros(p: Program, enabled: bool) -> Program:
     processed_program = Program(instructions=[])
     # dreg is the discard register
     dreg = "r7"
-    log.warn("USING MACROS, PLEASE MAKE SURE YOUR CODE DOES NOT USE r7")
+    log.warning("USING MACROS, PLEASE MAKE SURE YOUR CODE DOES NOT USE r7")
     for i in p.instructions:
         match i:
-            case Instruction("addi", [(OT.REGISTER, reg), (OT.IMMEDIATE, imm)]):
+            case Instruction("addi", [(OT.REGISTER, reg), (OT.IMMEDIATE, imm)], lbl):
                 some_applied = True
                 processed_program.instructions = processed_program.instructions + [
                     Instruction(
-                        "mov", [(OT.REGISTER, dreg), (OT.IMMEDIATE, imm)]),
+                        "mov", [(OT.REGISTER, dreg), (OT.IMMEDIATE, imm)], lbl),
                     Instruction(
                         "add", [(OT.REGISTER, reg), (OT.REGISTER, reg), (OT.REGISTER, dreg)]),
                 ]

--- a/programs/simon.s
+++ b/programs/simon.s
@@ -1,33 +1,30 @@
 ; general dibu mem addresses
 IO_IN = 0xfe
 IO_OUT = 0xff
+; simon mem addresses
 ANSWERS = 0xc0 ; from here, 4 addresses for each answer until 0xc3
 EXPECTED = 0xc4
+CURRENT_CHALLENGE = 0xc5 ; two words for current challenge, easier to handle
+;       7      4  3      0
+; 0xc5: [digit 1, digit 0]
+;       [digit 3, digit 2]
 ;;;;;;;;;;;;;;;
-; call conventions
+; conventions
 ; - returns are always in r6
+; - r7 is a discard register
 ;;;;;;;;;;;;;;;
 ; -------------
 ; main
 ; -------------
-main: mov r5 0x0 ; idx = 0
-mov r3 0xde
-load_test_answers: mov r4 $ANSWERS ; r4 = answers base addr
-add r4 r4 r5 ; r4 += idx
-str [r4] r3 ; answers[idx] = 0xde
-mov r4 $EXPECTED ; r4 = expected base addr
-add r4 r4 r5 ; r4 += idx
-str [r4] r3 ; expected[idx] = 0xde
-addi r5 0d1 ; idx++
-mov r7 0d4
-cmp r5 r7 ; jmp if idx < 4
-jn load_test_answers
-mov r6 0xcc
-str [$IO_OUT] r6 ; signal calling check_answers
-call check_answers
-str [$IO_OUT] r6 ; io_out = check_answers()
-mov r6 0xcd
-str [$IO_OUT] r6 ; signal already shown answer
+main: mov r4 0x81 ; challenge: 1 4 3 3
+mov r3 0x44
+mov r5 $CURRENT_CHALLENGE
+str [r5] r4
+addi r5 0d1
+str [r5] r3
+call debug_signal ; debug signal
+call display_challenge
+call debug_signal ; debug signal
 end: jmp end
 ; -------------
 ; CHECK ROUTINE - returns 0 if ok, 1 if not
@@ -52,4 +49,52 @@ jmp check_answers_loop
 check_answers_error: mov r6 0x1
 ret
 check_answers_ok: mov r6 0x0
+ret
+; -------------
+; DISPLAY CHALLENGE ROUTINE
+; uses r6, r5
+; -------------
+display_challenge: load r5 [$CURRENT_CHALLENGE] ; r5 = current_challenge
+str [$IO_OUT] r5 ; IO_OUT = current_challenge[0]
+call display_challenge_wait
+mov r6 0x4
+lsr r5 r5 r6 ; r5 = current_challenge >> 4
+str [$IO_OUT] r5 ; IO_OUT = current_challenge[1]
+call display_challenge_wait
+mov r5 $CURRENT_CHALLENGE
+addi r5 0d1
+load r5 [r5] ; r5 = current_challenge_1
+str [$IO_OUT] r5 ; IO_OUT = current_challenge[2]
+call display_challenge_wait
+mov r6 0x4
+lsr r5 r5 r6 ; r5 = current_challenge_1 >> 4
+str [$IO_OUT] r5 ; IO_OUT = current_challenge[3]
+call display_challenge_wait
+ret
+display_challenge_wait: mov r1 0d4 ; long wait
+call wait_routine
+mov r6 0x0
+str [$IO_OUT] r6 ; IO_OUT = 0
+mov r1 0d2 ; short wait displaying zero
+call wait_routine
+ret
+; -------------
+; WAIT ROUTINE
+; takes r1 wait iterations
+; -------------
+wait_routine: mov r7 r7; nop
+mov r7 r7; nop
+mov r7 r7; nop
+mov r7 r7; nop
+addi r1 0d-1 ; time--
+mov r7 0x0
+cmp r1 r7 ; time == 0
+jne wait_routine
+ret
+debug_signal: mov r7 0x0d
+str [$IO_OUT] r7 ; IO_OUT = de for debug
+mov r7 r7 ; nop
+mov r7 0x0e
+str [$IO_OUT] r7 ; IO_OUT = de for debug
+mov r7 r7 ; nop
 ret

--- a/programs/simon.s
+++ b/programs/simon.s
@@ -1,0 +1,55 @@
+; general dibu mem addresses
+IO_IN = 0xfe
+IO_OUT = 0xff
+ANSWERS = 0xc0 ; from here, 4 addresses for each answer until 0xc3
+EXPECTED = 0xc4
+;;;;;;;;;;;;;;;
+; call conventions
+; - returns are always in r6
+;;;;;;;;;;;;;;;
+; -------------
+; main
+; -------------
+main: mov r5 0x0 ; idx = 0
+mov r3 0xde
+load_test_answers: mov r4 $ANSWERS ; r4 = answers base addr
+add r4 r4 r5 ; r4 += idx
+str [r4] r3 ; answers[idx] = 0xde
+mov r4 $EXPECTED ; r4 = expected base addr
+add r4 r4 r5 ; r4 += idx
+str [r4] r3 ; expected[idx] = 0xde
+addi r5 0d1 ; idx++
+mov r7 0d4
+cmp r5 r7 ; jmp if idx < 4
+jn load_test_answers
+mov r6 0xcc
+str [$IO_OUT] r6 ; signal calling check_answers
+call check_answers
+str [$IO_OUT] r6 ; io_out = check_answers()
+mov r6 0xcd
+str [$IO_OUT] r6 ; signal already shown answer
+end: jmp end
+; -------------
+; CHECK ROUTINE - returns 0 if ok, 1 if not
+; uses r6, r5, r4, r3
+; -------------
+check_answers: mov r6 0x4
+mov r5 0x0 ; r5 is the idx in each 4-element array
+; bring first addresses
+; r4 and r3 are used for checking equality
+check_answers_loop: mov r4 $ANSWERS ; move base addr
+add r4 r4 r5 ; increment ansers += idx
+load r4 [r4] ; r4 = answers[]
+mov r3 $EXPECTED ; move base addr
+add r3 r3 r5 ; increment expected += idx
+load r3 [r3] ; r3 = expected[idx]
+cmp r3 r4 ; check expected[idx] == answers[idx]
+jne check_answers_error ; return -1
+addi r5 0d1 ; idx ++
+cmp r5 r6 ; idx == 4, means we've compared all
+je check_answers_ok
+jmp check_answers_loop
+check_answers_error: mov r6 0x1
+ret
+check_answers_ok: mov r6 0x0
+ret

--- a/rtl_tests/test_datapath.py
+++ b/rtl_tests/test_datapath.py
@@ -545,9 +545,9 @@ async def test_multiple_call_and_ret(dut):
 
 @cocotb.test()
 async def test_demo_program(dut):
-    with open("/home/pablo/facultad/dibu-architecture/programs/debug.s", "r") as f:
+    with open("/Users/pablo/Facultad/fpga/dibu-architecture/programs/simon.s", "r") as f:
         test_program = f.read()
-    test_compiled_program = assemble(parse(test_program))
+    test_compiled_program = assemble(parse(test_program), macros=True)
     print("programa compilado: \n%s" % (test_compiled_program))
 
     dut.run.value = 0

--- a/rtl_tests/test_datapath.py
+++ b/rtl_tests/test_datapath.py
@@ -87,6 +87,39 @@ async def test_two_registers_add(dut):
     assert dut.rbank.bank.value[5] == int("0xf1", base=16)
 
 @cocotb.test()
+async def test_addi_macro(dut):
+    test_program = """mov r3 0xf0
+    addi r3 0d1
+    halt 
+    """
+    test_compiled_program = assemble(parse(test_program))
+
+    dut.run.value = 0
+    dut.code_w_en.value = 0
+    cocotb.start_soon(Clock(dut.clk, 10, units="ns").start())
+
+    # wait a bit, 2 clk cycles
+    await Timer(20, units="ns")
+    await FallingEdge(dut.clk)
+
+    # write program
+    dut.code_w_en.value = 1
+    for i, l in enumerate(test_compiled_program.splitlines(keepends=False)):
+        dut.code_addr_in.value = i
+        dut.code_in.value = BinaryValue(l)
+        await FallingEdge(dut.clk)
+
+    # im in a falling edge, and code has been written
+
+    dut.code_w_en.value = 0
+    dut.run.value = 1
+
+    # memory has been written
+    await wait_until_halt(dut)
+
+    assert dut.rbank.bank.value[3] == int("0xf1", base=16)
+
+@cocotb.test()
 async def test_movf(dut):
     test_program = """mov r3 0x01
     mov r4 0x00

--- a/rtl_tests/test_datapath.py
+++ b/rtl_tests/test_datapath.py
@@ -572,7 +572,7 @@ async def test_demo_program(dut):
     dut.run.value = 1
 
     # memory has been written
-    await wait_until_halt(dut, max_clks=1000)
+    await wait_until_halt(dut, max_clks=2000)
 
 
 async def wait_until_halt(dut, max_clks=100):

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -151,6 +151,16 @@ class ParserTest(unittest.TestCase):
         assembled_program = assemble(parsed_program)
         self.assertEqual(expected, assembled_program)
 
+    def test_assemble_decimal_negative_immediate(self):
+        example = """mov r3 0d-1
+        """
+        expected = prepare_binary("""
+        0111101111111111
+        """)
+        parsed_program = parse(example)
+        assembled_program = assemble(parsed_program)
+        self.assertEqual(expected, assembled_program)
+
     def test_assemble_error(self):
         with self.assertRaises(ValueError) as ctx:
             example = """mov 0d14 0d14

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -74,7 +74,6 @@ class ParserTest(unittest.TestCase):
                     (OperandType.MEM_REGISTER, "r1"),
                 ]),
             ],
-            labels={},
         )
         self.assertEqual(prog, expected)
 
@@ -95,7 +94,7 @@ class ParserTest(unittest.TestCase):
                 Instruction("mov", [
                     (OperandType.REGISTER, "r1"),
                     (OperandType.IMMEDIATE, "00001111"),
-                ]),
+                ], label="start"),
                 Instruction("mov", [
                     (OperandType.REGISTER, "r1"),
                     (OperandType.IMMEDIATE, "0"*8),
@@ -103,7 +102,7 @@ class ParserTest(unittest.TestCase):
                 Instruction("jmp", [
                     (OperandType.LABEL, "start"),
                 ]),
-                Instruction("halt", []),
+                Instruction("halt", [], label="end"),
                 Instruction("jmp", [
                     (OperandType.LABEL, "end"),
                 ]),
@@ -117,10 +116,6 @@ class ParserTest(unittest.TestCase):
                     (OperandType.LABEL, "end"),
                 ]),
             ],
-            labels={
-                "start": 0,
-                "end": 3,
-            },
         )
         self.assertEqual(prog, expected)
         expected = prepare_binary("""
@@ -184,7 +179,6 @@ class ParserTest(unittest.TestCase):
                             (OperandType.IMMEDIATE, "11111111")]),
                 Instruction("halt", [])
             ],
-            labels={},
         )
         self.assertEqual(prog, expected)
 
@@ -203,7 +197,6 @@ class ParserTest(unittest.TestCase):
                             (OperandType.IMMEDIATE, "00000011")]),
                 Instruction("halt", [])
             ],
-            labels={},
         )
         self.assertEqual(prog, expected)
 
@@ -212,7 +205,7 @@ class ParserTest(unittest.TestCase):
         halt
         """
         prog = parse(example)
-        prog = apply_macros(prog)
+        prog = apply_macros(prog, True)
         expected = Program(
             instructions=[
                 Instruction("mov", [(OperandType.REGISTER, "r7"),
@@ -221,6 +214,5 @@ class ParserTest(unittest.TestCase):
                             (OperandType.REGISTER, "r3"), (OperandType.REGISTER, "r7")]),
                 Instruction("halt", [])
             ],
-            labels={},
         )
         self.assertEqual(prog, expected)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -124,8 +124,8 @@ class ParserTest(unittest.TestCase):
         )
         self.assertEqual(prog, expected)
         expected = prepare_binary("""
-        0100000100001111
-        0100000100000000
+        0111100100001111
+        0111100100000000
         1100000000000000
         1111111111111111
         1100000000000011
@@ -147,9 +147,8 @@ class ParserTest(unittest.TestCase):
         mov r4 r3
         not r5 r4
         """
-        # todo: improve this to ignore tailing and leading whitespace, and also dedent
         expected = prepare_binary("""
-        0100001111110000
+        0111101111110000
         0011110000011000
         0011010100100000
         """)
@@ -202,6 +201,24 @@ class ParserTest(unittest.TestCase):
                             (OperandType.MEM_IMMEDIATE, "00000011"), (OperandType.IMMEDIATE, "00001111")]),
                 Instruction("mov", [(OperandType.REGISTER, "r1"),
                             (OperandType.IMMEDIATE, "00000011")]),
+                Instruction("halt", [])
+            ],
+            labels={},
+        )
+        self.assertEqual(prog, expected)
+
+    def test_macros(self):
+        example = """addi r3 0d1
+        halt
+        """
+        prog = parse(example)
+        prog = apply_macros(prog)
+        expected = Program(
+            instructions=[
+                Instruction("mov", [(OperandType.REGISTER, "r7"),
+                            (OperandType.IMMEDIATE, "00000001")]),
+                Instruction("add", [(OperandType.REGISTER, "r3"),
+                            (OperandType.REGISTER, "r3"), (OperandType.REGISTER, "r7")]),
                 Instruction("halt", [])
             ],
             labels={},


### PR DESCRIPTION
## Macros
Now we support macros, which are meta instructions that are converted into more instructions. For example, `addi`

## Support for negative immediate

## Initial simon work
Coded routines that:
- check if two 4 element arrays are equal, useful for checking answers
- displays the challenge with long and short pauses

Display challenge example, note the interleaved sequence of `challenge[0], 0, challenge[1], 0, ...`

<img width="985" alt="image" src="https://github.com/thepalbi/dibu-architecture/assets/2617411/b8396dd5-6eeb-406a-81c6-76325408c5c2">

Display wrong answer:

<img width="708" alt="image" src="https://github.com/thepalbi/dibu-architecture/assets/2617411/6b9043c4-a832-4d46-8632-9239f4ebfe62">
